### PR TITLE
fix: correct typo in variable name

### DIFF
--- a/render.py
+++ b/render.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         gaussExtractor.gaussians.active_sh_degree = 0
         gaussExtractor.reconstruction(scene.getTrainCameras())
         # extract the mesh and save
-        if config.pipelinegs.unbounded:
+        if config.pipeline.unbounded:
             name = 'fuse_unbounded.ply'
             mesh = gaussExtractor.extract_mesh_unbounded(resolution=config.pipeline.mesh_res)
         else:


### PR DESCRIPTION
Corrected a typo in the variable name `pipelinegs` which caused potential readability and maintainability issues. The variable is now named correctly for consistent usage throughout the code.